### PR TITLE
#3 주문 상태 UI

### DIFF
--- a/src/app/order-status/page.tsx
+++ b/src/app/order-status/page.tsx
@@ -1,0 +1,5 @@
+import OrderStatusScreen from '@/pages/OrderStatusScreen'
+
+export default function Page() {
+  return <OrderStatusScreen />
+}

--- a/src/components/orderStatus/OrderDetail.test.tsx
+++ b/src/components/orderStatus/OrderDetail.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import OrderDetail from './OrderDetail'
+
+describe('OrderDetail', () => {
+  it('주문 번호, 가게 이름, 주문 목록, 합계 금액을 출력해야 한다.', () => {
+    render(
+      <OrderDetail
+        orderId="12345"
+        storeName="굽네치킨"
+        orderList={[
+          {
+            name: '후라이드치킨',
+            option: '순살',
+            count: 1,
+          },
+          {
+            name: '양념치킨',
+            option: '뼈',
+            count: 2,
+          },
+        ]}
+        totalPrice="48,000"
+      />,
+    )
+
+    expect(screen.getByText('12345 주문')).toBeInTheDocument()
+    expect(screen.getByText('굽네치킨')).toBeInTheDocument()
+    expect(screen.getByText('후라이드치킨')).toBeInTheDocument()
+    expect(screen.getByText('순살')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('양념치킨')).toBeInTheDocument()
+    expect(screen.getByText('뼈')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('합계: 48,000원')).toBeInTheDocument()
+  })
+})

--- a/src/components/orderStatus/OrderDetail.tsx
+++ b/src/components/orderStatus/OrderDetail.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+interface OrderDetailProps {
+  orderId: string
+  storeName: string
+  orderList: {
+    name: string
+    option: string
+    count: number
+  }[]
+  totalPrice: string
+}
+
+const OrderDetail = ({ orderId, storeName, orderList, totalPrice }: OrderDetailProps) => {
+  return (
+    <div className="flex flex-col gap-6 pt-5">
+      <p className="text-xl font-semibold">{orderId} 주문</p>
+      <p>{storeName}</p>
+      {orderList.map((order, index) => (
+        <div key={order.name} className="mb-3 flex gap-3">
+          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-300">
+            {order.count}
+          </div>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm">{order.name}</p>
+            <p className="text-sm">{order.option}</p>
+          </div>
+        </div>
+      ))}
+
+      <div>
+        <p className="ml-10 text-xl font-semibold">합계: {totalPrice}원</p>
+      </div>
+    </div>
+  )
+}
+
+export default OrderDetail

--- a/src/components/orderStatus/OrderStatusItem.tsx
+++ b/src/components/orderStatus/OrderStatusItem.tsx
@@ -1,0 +1,25 @@
+import clsx from 'clsx'
+import { Dot } from 'lucide-react'
+import React from 'react'
+
+interface OrderStatusItemProps {
+  isActivated: boolean
+  name: string
+}
+
+const OrderStatusItem = ({ isActivated, name }: OrderStatusItemProps) => {
+  return (
+    <li className="flex">
+      <Dot className={isActivated ? 'text-main' : ''} />
+      <p
+        className={clsx('font-semibold', {
+          'text-main': isActivated,
+        })}
+      >
+        {name}
+      </p>
+    </li>
+  )
+}
+
+export default OrderStatusItem

--- a/src/components/orderStatus/OrderStatusTrack.test.tsx
+++ b/src/components/orderStatus/OrderStatusTrack.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import OrderStatusTrack from './OrderStatusTrack'
+
+describe('OrderStatusTrack', () => {
+  const PendingOrderStatusTrack = () => (
+    <OrderStatusTrack address="서울특별시 관악구 OO아파트" status="pending" />
+  )
+
+  const AcceptedOrderStatusTrack = () => (
+    <OrderStatusTrack
+      address="서울특별시 관악구 OO아파트"
+      status="accepted"
+      orderArrivalTime="오후 05:18"
+      remainingDeliveryTime={15}
+    />
+  )
+
+  const PreparingOrderStatusTrack = () => (
+    <OrderStatusTrack
+      address="서울특별시 강남구 OO아파트"
+      status="preparing"
+      orderArrivalTime="오후 05:18"
+      remainingDeliveryTime={15}
+    />
+  )
+
+  const DeliveringOrderStatusTrack = () => (
+    <OrderStatusTrack
+      address="서울특별시 서초구 OO아파트"
+      status="delivering"
+      orderArrivalTime="오후 05:18"
+      remainingDeliveryTime={15}
+    />
+  )
+
+  const DeliveredOrderStatusTrack = () => (
+    <OrderStatusTrack
+      address="경기도 부천시 OO아파트"
+      status="delivered"
+      orderArrivalTime="오후 05:18"
+      remainingDeliveryTime={15}
+    />
+  )
+
+  const MAIN_COLOR = '#0FA5FA'
+
+  it("주문 상태가 pending일 때 '매장에서 주문을 확인하고 있습니다.'를 출력해야 한다.", () => {
+    render(PendingOrderStatusTrack())
+
+    expect(screen.getByText('매장에서 주문을 확인하고 있습니다.')).toBeInTheDocument()
+  })
+
+  it('주문 상태가 pending일 때 주문 취소 버튼과 조리 시작 후 취소 불가 문구를 출력해야 한다.', () => {
+    render(PendingOrderStatusTrack())
+
+    expect(screen.getByRole('button', { name: '주문 취소' })).toBeInTheDocument()
+    expect(screen.getByText('매장에서 조리를 시작하면 취소 할 수 없습니다.')).toBeInTheDocument()
+  })
+
+  it('주문 상태와 상관 없이 배달 주소를 출력해야 한다.', () => {
+    render(AcceptedOrderStatusTrack())
+
+    expect(screen.getByText('서울특별시 관악구 OO아파트')).toBeInTheDocument()
+  })
+
+  it('주문 상태가 pending이 아닐 때 남은 배달 시간과 도착 예정 시간, 배달 단계를 출력해야 한다.', () => {
+    render(AcceptedOrderStatusTrack())
+
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('오후 05:18 도착예정')).toBeInTheDocument()
+    expect(screen.getByText('주문 수락됨')).toBeInTheDocument()
+    expect(screen.getByText('메뉴 준비중')).toBeInTheDocument()
+    expect(screen.getByText('배달중')).toBeInTheDocument()
+    expect(screen.getByText('배달 완료')).toBeInTheDocument()
+  })
+
+  it("주문 상태가 accepted일 때 '주문 수락됨'을 출력하고 색상이 main 색상이어야 한다.", () => {
+    render(AcceptedOrderStatusTrack())
+
+    expect(screen.getByText('주문 수락됨')).toHaveClass('text-main')
+  })
+
+  it("주문 상태가 preparing일 때 '메뉴 준비중'을 출력하고 색상이 main 색상이어야 한다.", () => {
+    render(PreparingOrderStatusTrack())
+
+    expect(screen.getByText('메뉴 준비중')).toHaveClass('text-main')
+  })
+
+  it("주문 상태가 delivering일 때 '배달중'을 출력하고 색상이 main 색상이어야 한다.", () => {
+    render(DeliveringOrderStatusTrack())
+
+    expect(screen.getByText('배달중')).toHaveClass('text-main')
+  })
+
+  it("주문 상태가 delivered일 때 '배달 완료'를 출력하고 색상이 main 색상이어야 한다.", () => {
+    render(DeliveredOrderStatusTrack())
+
+    expect(screen.getByText('배달 완료')).toHaveClass('text-main')
+  })
+})

--- a/src/components/orderStatus/OrderStatusTrack.tsx
+++ b/src/components/orderStatus/OrderStatusTrack.tsx
@@ -2,6 +2,26 @@ import clsx from 'clsx'
 import { Dot } from 'lucide-react'
 import React from 'react'
 
+const OrderStatusItemList = [
+  {
+    name: '주문 수락됨',
+    status: 'accepted',
+  },
+  {
+    name: '메뉴 준비중',
+    status: 'preparing',
+  },
+  {
+    name: '배달중',
+
+    status: 'delivering',
+  },
+  {
+    name: '배달 완료',
+    status: 'delivered',
+  },
+]
+
 interface OrderDetailProps {
   status: 'pending' | 'accepted' | 'preparing' | 'delivering' | 'delivered'
   address: string
@@ -40,38 +60,18 @@ const OrderStatusTrack = ({
             <p>{orderArrivalTime} 도착예정</p>
           </div>
           <ul className="mb-6 ml-6 flex flex-col gap-4">
-            <li
-              className={clsx('flex', {
-                'text-main': status === 'accepted',
-              })}
-            >
-              <Dot />
-              <p className="font-semibold">주문 수락됨</p>
-            </li>
-            <li
-              className={clsx('flex', {
-                'text-main': status === 'preparing',
-              })}
-            >
-              <Dot />
-              <p className="font-semibold">메뉴 준비중</p>
-            </li>
-            <li
-              className={clsx('flex', {
-                'text-main': status === 'delivering',
-              })}
-            >
-              <Dot />
-              <p className="font-semibold">배달중</p>
-            </li>
-            <li
-              className={clsx('flex', {
-                'text-main': status === 'delivered',
-              })}
-            >
-              <Dot />
-              <p className="font-semibold">배달 완료</p>
-            </li>
+            {OrderStatusItemList.map((item) => (
+              <li key={item.status} className="flex">
+                <Dot className={status === item.status ? 'text-main' : ''} />
+                <p
+                  className={clsx('font-semibold', {
+                    'text-main': status === item.status,
+                  })}
+                >
+                  {item.name}
+                </p>
+              </li>
+            ))}
           </ul>
         </>
       )}

--- a/src/components/orderStatus/OrderStatusTrack.tsx
+++ b/src/components/orderStatus/OrderStatusTrack.tsx
@@ -1,0 +1,86 @@
+import clsx from 'clsx'
+import { Dot } from 'lucide-react'
+import React from 'react'
+
+interface OrderDetailProps {
+  status: 'pending' | 'accepted' | 'preparing' | 'delivering' | 'delivered'
+  address: string
+  remainingDeliveryTime?: number
+  orderArrivalTime?: string
+}
+
+const OrderStatusTrack = ({
+  status,
+  address,
+  orderArrivalTime,
+  remainingDeliveryTime,
+}: OrderDetailProps) => {
+  return (
+    <div className="border-b-2">
+      {/* 주문 수락 전 */}
+      {status === 'pending' && (
+        <>
+          <div className="mb-8 flex items-center gap-4">
+            <Dot className="text-main" />
+            <p className="text-base font-semibold text-main">매장에서 주문을 확인하고 있습니다.</p>
+          </div>
+          <div className="mb-12 flex flex-col items-center gap-4">
+            <button className="h-8 w-24 rounded-sm border-2">주문 취소</button>
+            <p className="text-sm">매장에서 조리를 시작하면 취소 할 수 없습니다.</p>
+          </div>
+        </>
+      )}
+      {/* 주문 수락 후 */}
+      {status !== 'pending' && (
+        <>
+          <div className="mb-6 flex items-center justify-between">
+            <p className="font-semibold">
+              <span className="text-3xl">{remainingDeliveryTime}</span>분
+            </p>
+            <p>{orderArrivalTime} 도착예정</p>
+          </div>
+          <ul className="mb-6 ml-6 flex flex-col gap-4">
+            <li
+              className={clsx('flex', {
+                'text-main': status === 'accepted',
+              })}
+            >
+              <Dot />
+              <p className="font-semibold">주문 수락됨</p>
+            </li>
+            <li
+              className={clsx('flex', {
+                'text-main': status === 'preparing',
+              })}
+            >
+              <Dot />
+              <p className="font-semibold">메뉴 준비중</p>
+            </li>
+            <li
+              className={clsx('flex', {
+                'text-main': status === 'delivering',
+              })}
+            >
+              <Dot />
+              <p className="font-semibold">배달중</p>
+            </li>
+            <li
+              className={clsx('flex', {
+                'text-main': status === 'delivered',
+              })}
+            >
+              <Dot />
+              <p className="font-semibold">배달 완료</p>
+            </li>
+          </ul>
+        </>
+      )}
+      <div className="flex flex-col gap-4 pb-12">
+        <p className="text-xl font-semibold">배달 주소</p>
+        <p>{address}</p>
+      </div>
+    </div>
+  )
+}
+
+export default OrderStatusTrack

--- a/src/components/orderStatus/OrderTrackMap.tsx
+++ b/src/components/orderStatus/OrderTrackMap.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+const OrderTrackMap = () => {
+  return <div className="h-[240px] w-full bg-gray-300"></div>
+}
+export default OrderTrackMap

--- a/src/pages/OrderStatusScreen.tsx
+++ b/src/pages/OrderStatusScreen.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { X } from 'lucide-react'
+import Link from 'next/link'
+import OrderDetail from '@/components/orderStatus/OrderDetail'
+import OrderTrackMap from '@/components/orderStatus/OrderTrackMap'
+import OrderStatusTrack from '@/components/orderStatus/OrderStatusTrack'
+
+const OrderStatusScreen = () => {
+  return (
+    <div>
+      <div className="absolute top-0 w-full p-4">
+        <Link href={'/'}>
+          <X />
+        </Link>
+      </div>
+      <OrderTrackMap />
+      <div className="mx-6 py-5">
+        <OrderStatusTrack
+          remainingDeliveryTime={15}
+          status="preparing"
+          address="서울특별시 관악구 OO아파트"
+          orderArrivalTime="오후 05:18"
+        />
+        <OrderDetail
+          orderId="OYWORO"
+          storeName="굽네치킨 미아점"
+          orderList={[{ name: '후라이드치킨', option: '순살', count: 1 }]}
+          totalPrice="16,000"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default OrderStatusScreen

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,80 +1,81 @@
-import type { Config } from "tailwindcss"
+import type { Config } from 'tailwindcss'
 
 const config = {
-  darkMode: ["class"],
+  darkMode: ['class'],
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
-	],
-  prefix: "",
+  ],
+  prefix: '',
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: '2rem',
       screens: {
-        "2xl": "1400px",
+        '2xl': '1400px',
       },
     },
     extend: {
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        main: '#0FA5FA',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
         },
         popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
       },
       keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
         },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
         },
       },
       animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require('tailwindcss-animate')],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
#3 주문 상태 UI입니다.

구현된 사항에 대한 내용과 테스트 하는 방법은 이슈를 참고해주세요.
아래 내용은 작성한 코드의 의도를 알기 쉽도록 설명한 내용입니다.
한번 읽어보시고 코드를 보시면 더 이해하기 쉬우실 거 같습니다.

# 컴포넌트 구조
nextjs에서 라우팅을 위해 기본적으로 만들어야 하는 page 파일을 만들고, 해당 page의 내용은 pages 폴더에 Screen 컴포넌트로 따로 빼두었습니다.
이렇게 해둔 이유는 이전에 컨벤션 회의 때 이렇게 하기로 했던걸로 기억 합니다. 제가 잘 못 기억하고 있다면 알려주세요. 수정하도록 하겠습니다.  

컴포넌트 폴더에 각 페이지 이름의 폴더에는 페이지에서만 사용되는(공통으로 사용될 여지가 없는) 컴포넌트를 위치 시켰습니다.
추후에 공통으로 사용되는 컴포넌트는 shared 폴더를 만들어서 이동시키면 좋을거 같습니다.
글씨 크기에 따라 반복되는 같은 스타일의 p태그가 있는데, 공통된 부분을 정의하기엔 아직 이른거 같아서 일단은 분리하지 않고 그대로 두었습니다. 차후에 기준이 마련되면 글자 컴포넌트를 만들어서 프로젝트 전체에서 통일된 글자 양식을 사용하면 좋겠습니다.

컴포넌트는 되도록 UI를 그리는데 집중할 수 있도록 구성했습니다. 데이터는 Screen 컴포넌트 (혹은 Page컴포넌트)에서 관리하고 UI 컴포넌트에 필요한 데이터만 주입하는 방식이 유지보수에도 쉽고 테스트도 쉽다고 생각했습니다.

PR 확인하시고 이상 없으면 승인 및 머지 해주시면 감사하겠습니다.