### PR TITLE
#39 주문내역 UI

### DIFF
--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -1,0 +1,79 @@
+'use client'
+import OrderCard from '@/components/order/OrderCard'
+import Tabs from '@/components/order/Tabs'
+import { useState } from 'react'
+
+interface Order {
+  id: number
+  storeName: string
+  date: string
+  deliveryStatus: 'Delivered' | 'Pending'
+  menuItems: { name: string; quantity: number }[]
+  totalAmount: number
+}
+
+const mockOrders: Order[] = [
+  {
+    id: 1,
+    storeName: '우리집 밥상',
+    date: '2022-07-11 오후 07:06',
+    deliveryStatus: 'Delivered',
+    menuItems: [
+      { name: '김치찌개', quantity: 2 },
+      { name: '불고기', quantity: 1 },
+    ],
+    totalAmount: 25000,
+  },
+  {
+    id: 2,
+    storeName: '홍콩반점',
+    date: '2024-08-11 오후 07:06',
+    deliveryStatus: 'Delivered',
+    menuItems: [{ name: '짜장면', quantity: 3 }],
+    totalAmount: 18000,
+  },
+  {
+    id: 3,
+    storeName: '치킨마을',
+    date: '2024-08-10 오후 07:06',
+    deliveryStatus: 'Delivered',
+    menuItems: [{ name: '후라이드치킨', quantity: 1 }],
+    totalAmount: 20000,
+  },
+  {
+    id: 4,
+    storeName: '치킨마을',
+    date: '2022-07-11 오후 07:06',
+    deliveryStatus: 'Delivered',
+    menuItems: [{ name: '후라이드치킨', quantity: 1 }],
+    totalAmount: 20000,
+  },
+]
+
+const OrderPage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<'past' | 'preparing'>('past')
+
+  const handleTabClick = (tab: 'past' | 'preparing') => {
+    setActiveTab(tab)
+  }
+
+  return (
+    <div className="flex h-screen flex-col">
+      <Tabs activeTab={activeTab} onTabClick={handleTabClick} />
+
+      <div className="flex-1 overflow-y-auto p-4 pb-[4.5rem]">
+        {activeTab === 'past' ? (
+          <div className="space-y-4">
+            {mockOrders.map((order) => (
+              <OrderCard key={order.id} order={order} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center text-gray-500">준비중인 주문이 없습니다.</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OrderPage

--- a/src/components/order/OrderCard.test.tsx
+++ b/src/components/order/OrderCard.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import OrderCard from './OrderCard'
+
+// Order 타입을 가져옵니다.
+interface Order {
+  id: number
+  storeName: string
+  date: string
+  deliveryStatus: 'Delivered' | 'Pending'
+  menuItems: { name: string; quantity: number }[]
+  totalAmount: number
+}
+
+describe('OrderCard', () => {
+  const mockOrder: Order = {
+    id: 1,
+    storeName: 'Test Store',
+    date: '2024-09-03',
+    deliveryStatus: 'Delivered', // 'Delivered'로 정확히 지정합니다.
+    menuItems: [
+      { name: 'Item 1', quantity: 2 },
+      { name: 'Item 2', quantity: 1 },
+    ],
+    totalAmount: 30000,
+  }
+
+  test('주문 정보가 올바르게 렌더링된다', () => {
+    render(<OrderCard order={mockOrder} />)
+
+    // 상점 이름이 올바르게 표시되는지 확인합니다.
+    expect(screen.getByText('Test Store')).toBeInTheDocument()
+
+    // 주문 날짜가 올바르게 표시되는지 확인합니다.
+    expect(screen.getByText('2024-09-03')).toBeInTheDocument()
+
+    // 배달 상태가 올바르게 표시되는지 확인합니다.
+    expect(screen.getByText('배달 완료')).toBeInTheDocument()
+
+    // 메뉴 아이템이 올바르게 렌더링되는지 확인합니다.
+    expect(screen.getByText('Item 1 x 2')).toBeInTheDocument()
+    expect(screen.getByText('Item 2 x 1')).toBeInTheDocument()
+
+    // 합계 금액이 올바르게 표시되는지 확인합니다.
+    expect(screen.getByText('합계 금액: 30,000원')).toBeInTheDocument()
+
+    // '리뷰쓰기' 버튼이 렌더링되는지 확인합니다.
+    expect(screen.getByText('리뷰쓰기')).toBeInTheDocument()
+  })
+
+  test('배달 상태가 "배달 중"일 때 올바르게 표시되는지 확인한다', () => {
+    const pendingOrder: Order = { ...mockOrder, deliveryStatus: 'Pending' }
+    render(<OrderCard order={pendingOrder} />)
+
+    expect(screen.getByText('배달 중')).toBeInTheDocument()
+  })
+})

--- a/src/components/order/OrderCard.tsx
+++ b/src/components/order/OrderCard.tsx
@@ -1,0 +1,30 @@
+'use client'
+import * as React from 'react'
+interface Order {
+  id: number
+  storeName: string
+  date: string
+  deliveryStatus: 'Delivered' | 'Pending'
+  menuItems: { name: string; quantity: number }[]
+  totalAmount: number
+}
+export default function OrderCard({ order }: { order: Order }) {
+  return (
+    <div className="flex flex-col rounded-lg border p-4">
+      <h3 className="text-2xl font-bold">{order.storeName}</h3>
+      <span className="text-xs text-gray-500">{order.date}</span>
+      <div className="mb-2 text-gray-600">
+        {order.deliveryStatus === 'Delivered' ? '배달 완료' : '배달 중'}
+      </div>
+      <div className="mb-2 text-sm">
+        {order.menuItems.map((item, index) => (
+          <div key={index}>
+            {item.name} x {item.quantity}
+          </div>
+        ))}
+      </div>
+      <span className="font-semibold">합계 금액: {order.totalAmount.toLocaleString()}원</span>
+      <button className="my-4 bg-[#0FA5FA] p-2 text-white hover:underline">리뷰쓰기</button>
+    </div>
+  )
+}

--- a/src/components/order/Tabs.test.tsx
+++ b/src/components/order/Tabs.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Tabs from './Tabs'
+
+describe('Tabs', () => {
+  test('올바른 탭이 활성화되어 있는지 확인', () => {
+    const onTabClickMock = jest.fn()
+    render(<Tabs activeTab="past" onTabClick={onTabClickMock} />)
+
+    const pastButton = screen.getByText('과거 주문내역')
+    expect(pastButton).toHaveClass('border-b-2 border-black font-semibold')
+
+    const preparingButton = screen.getByText('준비중')
+    expect(preparingButton).not.toHaveClass('border-b-2 border-black font-semibold')
+  })
+
+  test('탭 클릭 시 콜백 함수가 호출되는지 확인', () => {
+    const onTabClickMock = jest.fn()
+    render(<Tabs activeTab="past" onTabClick={onTabClickMock} />)
+
+    const preparingButton = screen.getByText('준비중')
+    fireEvent.click(preparingButton)
+
+    expect(onTabClickMock).toHaveBeenCalledWith('preparing')
+  })
+
+  test('올바른 스타일이 각 탭에 적용되는지 확인', () => {
+    const onTabClickMock = jest.fn()
+    render(<Tabs activeTab="preparing" onTabClick={onTabClickMock} />)
+
+    const preparingButton = screen.getByText('준비중')
+    expect(preparingButton).toHaveClass('border-b-2 border-black font-semibold')
+
+    const pastButton = screen.getByText('과거 주문내역')
+    expect(pastButton).not.toHaveClass('border-b-2 border-black font-semibold')
+  })
+})

--- a/src/components/order/Tabs.tsx
+++ b/src/components/order/Tabs.tsx
@@ -1,0 +1,31 @@
+'use client'
+import * as React from 'react'
+
+export default function Tabs({
+  activeTab,
+  onTabClick,
+}: {
+  activeTab: 'past' | 'preparing'
+  onTabClick: (tab: 'past' | 'preparing') => void
+}) {
+  return (
+    <div className="flex border-b bg-white pt-2">
+      <button
+        className={`flex-1 px-4 py-2 text-center ${
+          activeTab === 'past' ? 'border-b-2 border-black font-semibold' : ''
+        }`}
+        onClick={() => onTabClick('past')}
+      >
+        과거 주문내역
+      </button>
+      <button
+        className={`flex-1 px-4 py-2 text-center ${
+          activeTab === 'preparing' ? 'border-b-2 border-black font-semibold' : ''
+        }`}
+        onClick={() => onTabClick('preparing')}
+      >
+        준비중
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
https://github.com/FC-InnerCircle/icd01-team01-o2o1-fe/issues/39
주문내역 화면을 구현하였습니다.
과거 주문내역 탭 클릭 시 이전 주문 내역이 나오도록 하였습니다.
주문 중 탭과 리뷰 쓰기는 생성되어 있는 페이지와 추후에 연결할 예정입니다.