### PR TITLE
[FIX] 메인 주소 변경 시 주소 정보, 음식점 목록 캐싱 초기화

### DIFF
--- a/src/app/home/_components/AddressContainer.tsx
+++ b/src/app/home/_components/AddressContainer.tsx
@@ -14,7 +14,7 @@ export default function AddressContainer() {
   console.log(mainAddress?.addressDetail)
 
   return (
-    <Link href={'/my/address/search'} className="mb-4 flex items-center justify-start">
+    <Link href={'/my/address'} className="mb-4 flex items-center justify-start">
       <MapPin size={20} />
       <p>
         {mainAddress?.address} {mainAddress?.addressDetail}

--- a/src/app/my/address/_components/AddressList.tsx
+++ b/src/app/my/address/_components/AddressList.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { StarFilledIcon } from '@radix-ui/react-icons'
 import { Separator } from '@/components/ui/separator'
 import { useAddressList, useDeleteAddress, useUpdateMainAddress } from '@/features/address/query'
+import { useQueryClient } from '@tanstack/react-query'
 
 type AddressData = {
   addressId: number
@@ -32,13 +33,25 @@ export default AddressList
 const AddressListItem = ({ ...props }: AddressData) => {
   const { mutate: deleteAddress } = useDeleteAddress()
   const { mutate: updateMainAddress } = useUpdateMainAddress()
+  const queryClient = useQueryClient()
+
+  const handleChangeMainAddress = () => {
+    if (props.addressStatus === 'main') return
+
+    queryClient.invalidateQueries({
+      queryKey: ['address'],
+    })
+
+    queryClient.invalidateQueries({
+      queryKey: ['storeList', '', null],
+    })
+    updateMainAddress(props.addressId)
+  }
+
   return (
     <>
       <li key={props.addressId} className="flex h-12 items-center justify-between bg-white p-3">
-        <button
-          className="flex items-center space-x-3"
-          onClick={() => props.addressStatus !== 'main' && updateMainAddress(props.addressId)}
-        >
+        <button className="flex items-center space-x-3" onClick={handleChangeMainAddress}>
           <StarFilledIcon
             className={`h-5 w-5 ${
               props.addressStatus == 'main' ? 'text-yellow-400' : 'text-gray-400'

--- a/src/app/my/address/page.tsx
+++ b/src/app/my/address/page.tsx
@@ -7,23 +7,13 @@ import React from 'react'
 import { PlusCircledIcon } from '@radix-ui/react-icons'
 import { useRouter } from 'next/navigation'
 import AddressList from './_components/AddressList'
-import Link from 'next/link'
-import { ArrowLeft } from 'lucide-react'
 
 const ManagedAddressPage = () => {
   const router = useRouter()
 
-  const BackToSettingLink = () => {
-    return (
-      <Link href="/my">
-        <ArrowLeft size={24} />
-      </Link>
-    )
-  }
-
   return (
     <div>
-      <Header left={<BackToSettingLink />} center="주소 관리" />
+      <Header left={<BackButton />} center="주소 관리" />
       <div className="p-4" onClick={() => router.push('/my/address/search')}>
         <PlusCircledIcon className="my-1 mr-1 inline size-5 text-[#0FA5FA]" />새 주소 추가
       </div>


### PR DESCRIPTION
#112 

메인 주소를 변경하면, 주소 정보와 음식점 목록의 캐싱을 초기화 시켜 새로고침 없이도 
변경된 주소 기반의 음식점 목록을 새로 출력하도록 수정하였습니다.